### PR TITLE
Add support for manually specifying commands.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -3,14 +3,16 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/fatih/color"
 )
 
 // Options contains CLI arguments passed to the program.
 type Options struct {
-	Help    bool
-	PkgOnly bool
+	Help     bool
+	PkgOnly  bool
+	Commands []string
 }
 
 // ParseOptions parses the command line options and returns a struct filled with
@@ -20,7 +22,10 @@ func ParseOptions() Options {
 
 	flag.BoolVar(&opt.Help, "help", false, "Show help.")
 	flag.BoolVar(&opt.PkgOnly, "package", false, "Only vendor package level dependencies.")
+	commandraw := ""
+	flag.StringVar(&commandraw, "commands", "tidy,download,vendor", "The commands to run before vendoring")
 	flag.Parse()
+	opt.Commands = strings.Split(commandraw, ",")
 
 	return opt
 }

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -12,9 +12,7 @@ import (
 
 // UpdateModule makes sure the module is updated ready to vendor the
 // dependencies.
-func UpdateModule() {
-	var commands = []string{"tidy", "download", "vendor"}
-
+func UpdateModule(commands []string) {
 	for _, command := range commands {
 		cmd := exec.Command("go", "mod", command)
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ func main() {
 		options.PrintUsage()
 
 	} else {
-		cli.UpdateModule()
+		cli.UpdateModule(options.Commands)
 		json := cli.ReadDownloadJSON()
 		deps := file.ParseDownloadJSON(json)
 


### PR DESCRIPTION
In some cases go mod tidy can introduce a new dependency. Thus if you
try and run vend as part of a build process, you will get non
deterministic results as the upstream modules changes.